### PR TITLE
Use PUBLIC keyword when linking with robotlib

### DIFF
--- a/robot-lib/robot-lib.txt
+++ b/robot-lib/robot-lib.txt
@@ -1,2 +1,2 @@
 add_subdirectory(robot-lib robot)
-target_link_libraries(${LF_MAIN_TARGET} robot)
+target_link_libraries(${LF_MAIN_TARGET} PUBLIC robot)


### PR DESCRIPTION
This is needed to support v0.7