### PR TITLE
Update `nixpkgs` to version 25.05 in `flake.nix`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "lf-pico dev env";
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-23.05";
+    nixpkgs.url = "nixpkgs/nixos-25.05";
     flake-utils.url = "github:numtide/flake-utils";
     # lingo
     # lf binaries


### PR DESCRIPTION
The updated `pico-sdk` version (2.2.0) required `picotool` (2.1.1), and the nix package manager was not fetching the new `picotool` version. This ended up to download the new `picotool` everytime we are doing `lfc`.

```
CMake Warning at /Users/dkim314/project/temp/pico-sdk/tools/Findpicotool.cmake:30 (message):
  No installed picotool with version 2.1.1 found - building from source

  It is recommended to build and install picotool separately, or to set
  PICOTOOL_FETCH_FROM_GIT_PATH to a common directory for all your SDK
  projects
Call Stack (most recent call first):
  /Users/dkim314/project/temp/pico-sdk/tools/CMakeLists.txt:168 (find_package)
  /Users/dkim314/project/temp/pico-sdk/tools/CMakeLists.txt:688 (pico_init_picotool)
  /Users/dkim314/project/temp/pico-sdk/src/cmake/on_device.cmake:81 (picotool_postprocess_binary)
  CMakeLists.txt:66 (pico_add_extra_outputs)


Downloading Picotool
```

This PR updates `nixpkgs` to version 25.05 in `flake.nix`, and will fetch the new picotool version. Thanks to @the-systematic-chaos