### PR TITLE
Add math.h in Motors.lf due to `pico-sdk` version changes.

### DIFF
--- a/src/lib/Motors.lf
+++ b/src/lib/Motors.lf
@@ -18,6 +18,7 @@ target C {
 
 preamble {=
   #include <motors.h>
+  #include <math.h>
 =}
 
 reactor Motors {


### PR DESCRIPTION
The `Motors.lf` requires `math.h` to be included. Looks like this happened due to `pico-sdk` version changes.

```
[ 75%] Built target robot
[ 75%] Building C object CMakeFiles/RobotDriveSolution.dir/lib/schedule.c.o
[ 75%] Building C object CMakeFiles/RobotDriveSolution.dir/_robotdrivesolution_main.c.o
[ 76%] Building C object CMakeFiles/RobotDriveSolution.dir/_motors.c.o
[ 76%] Building C object CMakeFiles/RobotDriveSolution.dir/RobotDriveSolution.c.o
[ 76%] Building C object CMakeFiles/RobotDriveSolution.dir/_robot.c.o
[ 76%] Building C object CMakeFiles/RobotDriveSolution.dir/Users/dkim314/project/temp/pico-sdk/src/rp2_common/pico_stdlib/stdlib.c.o
[ 76%] Building C object CMakeFiles/RobotDriveSolution.dir/_display.c.o
[ 77%] Building C object CMakeFiles/RobotDriveSolution.dir/Users/dkim314/project/temp/pico-sdk/src/rp2_common/hardware_gpio/gpio.c.o
/Users/dkim314/project/temp/src/lib/Motors.lf: In function '_motors_method_set_power':
/Users/dkim314/project/temp/src/lib/Motors.lf:32:13: error: implicit declaration of function 'fabsf' [-Wimplicit-function-declaration]
   32 |     power = fabsf(power);
      |             ^~~~~
/Users/dkim314/project/temp/src/lib/Motors.lf:32:1: note: include '<math.h>' or provide a declaration of 'fabsf'
   31 |   method set_power(power: float, forward: bool, left: bool) {=
  +++ |+#include <math.h>
   32 |     power = fabsf(power);
make[2]: *** [CMakeFiles/RobotDriveSolution.dir/build.make:121: CMakeFiles/RobotDriveSolution.dir/_motors.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:2361: CMakeFiles/RobotDriveSolution.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
lfc: error: CMake failed with error code 2
lfc: error: Compilation was unsuccessful.
lfc: fatal error: Aborting due to 2 previous errors.
```

I just added this one line `#include <math.h>` in `src/motors.lf`